### PR TITLE
Bump version to `2.0.5`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quill-resize-module",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "A module for Quill rich text editor to allow images/iframe/video and custom elements(covert to placeholder) to be resized.",
   "main": "dist/resize.js",
   "module": "src/index.js",


### PR DESCRIPTION
Bumps version to `2.0.5`, allowing #18 bugfix to be published.

@mudoo , please take a look and consider publishing the `2.0.5`. Thanks.