### PR TITLE
Rework image alignment class attributor to support inline images

### DIFF
--- a/src/assets/resize.scss
+++ b/src/assets/resize.scss
@@ -95,18 +95,18 @@
   line-height: 1;
 }
 
-.ql-resize-style-left img {
+.ql-resize-style-left {
     float: left;
     margin: 0 1em 1em 0;
 }
-.ql-resize-style-center img {
+.ql-resize-style-center {
     display: block;
     margin: auto;
 }
-.ql-resize-style-right img {
+.ql-resize-style-right {
     float: right;
     margin: 0 0 1em 1em;
 }
-.ql-resize-style-full img {
+.ql-resize-style-full {
     width: 100% !important;
 }

--- a/src/modules/Toolbar.js
+++ b/src/modules/Toolbar.js
@@ -23,12 +23,20 @@ const ClassAttributor = Parchment.ClassAttributor
   ? Parchment.ClassAttributor
   : Parchment.Attributor.Class
 
-const ImageFormatClass = new ClassAttributor('imagestyle', 'ql-resize-style', {
-  scope: Parchment.Scope.INLINE,
+const IMAGE_FORMAT_ATTRIBUTOR = 'imagestyle'
+const ImageFormatClass = new ClassAttributor(IMAGE_FORMAT_ATTRIBUTOR, 'ql-resize-style', {
+  scope: Parchment.Scope.INLINE_BLOT,
+  whitelist: Object.values(ALIGNMENT_CLASSES)
+})
+
+const VIDEO_FORMAT_ATTRIBUTOR = 'videostyle'
+const VideoFormatClass = new ClassAttributor(VIDEO_FORMAT_ATTRIBUTOR, 'ql-resize-style', {
+  scope: Parchment.Scope.BLOCK_BLOT,
   whitelist: Object.values(ALIGNMENT_CLASSES)
 })
 
 Quill.register(ImageFormatClass, true)
+Quill.register(VideoFormatClass, true)
 
 export default class Toolbar extends BaseModule {
   static Icons = {
@@ -112,8 +120,7 @@ export default class Toolbar extends BaseModule {
           button.classList.add('active')
 
           if (tool.toolClass) {
-            const blotIndex = this.quill.getIndex(this.blot)
-            this.quill.formatText(blotIndex, 1, "imagestyle", tool.toolClass)
+            this._applyToolFormatting(tool.toolClass)
           }
         }
 
@@ -127,5 +134,17 @@ export default class Toolbar extends BaseModule {
       }
       this.toolbar.appendChild(button)
     })
+  }
+
+  _applyToolFormatting(toolClass) {
+    const blotIndex = this.quill.getIndex(this.blot)
+
+    if (this.blot.statics.scope === Parchment.Scope.INLINE_BLOT) {
+      // Format image
+      this.quill.formatText(blotIndex, 1, IMAGE_FORMAT_ATTRIBUTOR, toolClass)
+    } else if (this.blot.statics.scope === Parchment.Scope.BLOCK_BLOT) {
+      // Format video
+      this.quill.formatLine(blotIndex, 1, VIDEO_FORMAT_ATTRIBUTOR, toolClass)
+    }
   }
 }

--- a/src/modules/Toolbar.js
+++ b/src/modules/Toolbar.js
@@ -24,7 +24,7 @@ const ClassAttributor = Parchment.ClassAttributor
   : Parchment.Attributor.Class
 
 const ImageFormatClass = new ClassAttributor('imagestyle', 'ql-resize-style', {
-  scope: Parchment.Scope.BLOCK,
+  scope: Parchment.Scope.INLINE,
   whitelist: Object.values(ALIGNMENT_CLASSES)
 })
 
@@ -113,7 +113,7 @@ export default class Toolbar extends BaseModule {
 
           if (tool.toolClass) {
             const blotIndex = this.quill.getIndex(this.blot)
-            this.quill.formatLine(blotIndex, 1, "imagestyle", tool.toolClass)
+            this.quill.formatText(blotIndex, 1, "imagestyle", tool.toolClass)
           }
         }
 


### PR DESCRIPTION
The video embeds are considered block-scoped only.